### PR TITLE
set cHandle by WordPress pagename

### DIFF
--- a/controllers/dashboard/wordpress_import/import.php
+++ b/controllers/dashboard/wordpress_import/import.php
@@ -307,7 +307,11 @@ class DashboardWordpressImportImportController extends Controller{
 		}
 
 
-		$pageData = array('cName' => $pl->getTitle(),'cDatePublic'=>$pl->getPostdate(),'cDateAdded'=>$pl->getPostdate(),'cDescription' => $pl->getExcerpt(), 'uID'=> $uID, 'cHandle' => $pl->getPostName());
+		if ( "POST" == $pl->getPostType() ){
+			$pageData = array('cName' => $pl->getTitle(),'cDatePublic'=>$pl->getPostdate(),'cDateAdded'=>$pl->getPostdate(),'cDescription' => $pl->getExcerpt(), 'uID'=> $uID, 'cHandle' => $pl->getPostID());
+		} else {
+			$pageData = array('cName' => $pl->getTitle(),'cDatePublic'=>$pl->getPostdate(),'cDateAdded'=>$pl->getPostdate(),'cDescription' => $pl->getExcerpt(), 'uID'=> $uID, 'cHandle' => $pl->getPostName());
+		}
 		$newPage = $p->add($ct,$pageData);
 
           if (is_array($pl->getCategory())){

--- a/controllers/dashboard/wordpress_import/import.php
+++ b/controllers/dashboard/wordpress_import/import.php
@@ -175,6 +175,7 @@ class DashboardWordpressImportImportController extends Controller{
 			$dc = $item->children($namespaces['dc']);
 			$author = (string)$dc->creator;
 			$parentID = (int)$wp->post_parent;
+			$postName = (string)$wp->post_name;
 
                $out_tags = array();
                $out_categories = array();
@@ -197,6 +198,7 @@ class DashboardWordpressImportImportController extends Controller{
 			$p->setContent($content);
 			$p->setAuthor($author);
 			$p->setWpParentID($parentID);
+			$p->setPostName($postName);
 			$p->setPostDate($postDate);
 			$p->setPostType($postType);
 			$p->setCategory($out_categories);
@@ -305,7 +307,7 @@ class DashboardWordpressImportImportController extends Controller{
 		}
 
 
-		$pageData = array('cName' => $pl->getTitle(),'cDatePublic'=>$pl->getPostdate(),'cDateAdded'=>$pl->getPostdate(),'cDescription' => $pl->getExcerpt(), 'uID'=> $uID);
+		$pageData = array('cName' => $pl->getTitle(),'cDatePublic'=>$pl->getPostdate(),'cDateAdded'=>$pl->getPostdate(),'cDescription' => $pl->getExcerpt(), 'uID'=> $uID, 'cHandle' => $pl->getPostName());
 		$newPage = $p->add($ct,$pageData);
 
           if (is_array($pl->getCategory())){

--- a/models/page_lite.php
+++ b/models/page_lite.php
@@ -11,6 +11,7 @@ class PageLite extends Object{
      protected $tags;
 	protected $postDate;
 	protected $wpPostID; //needed to relate
+	protected $wpPostName; //needed to slug
 	function setPropertiesFromArray($array){
 		//TODO: maybe put some preg_replace here?
 		parent::setPropertiesFromArray($array);
@@ -81,5 +82,11 @@ class PageLite extends Object{
 	}
 	function getExcerpt(){
 		return $this->wpExcerpt;
+	}
+	function setPostName($post_name){
+		$this->wpPostName = $post_name;
+	}
+	function getPostName(){
+		return $this->wpPostName;
 	}
 }


### PR DESCRIPTION
I think better that path of imported pages are inherited from WordPress page name. These don't match often.
